### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM ntrrg/dotfiles

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - init: make
+image:
+  file: .gitpod.Dockerfile

--- a/.ntweb/index.en.md
+++ b/.ntweb/index.en.md
@@ -10,6 +10,7 @@ comments: true
 ---
 
 [![Docker Build Status](https://img.shields.io/docker/build/ntrrg/hugo.svg)](https://hub.docker.com/r/ntrrg/hugo)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ntrrg/docker-hugo)
 
 [Hugo]: https://gohugo.io
 

--- a/.ntweb/index.es.md
+++ b/.ntweb/index.es.md
@@ -10,6 +10,7 @@ comments: true
 ---
 
 [![Docker Build Status](https://img.shields.io/docker/build/ntrrg/hugo.svg)](https://hub.docker.com/r/ntrrg/hugo)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ntrrg/docker-hugo)
 
 [Hugo]: https://gohugo.io
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Docker Build Status](https://img.shields.io/docker/build/ntrrg/hugo.svg)](https://hub.docker.com/r/ntrrg/hugo)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ntrrg/docker-hugo)
 
 Dockerized Hugo CLI.
 


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.